### PR TITLE
13:Agent-memory and dynamic fragment naming

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -115,3 +115,24 @@ Created a blog layout with a responsive sidebar, a dynamic list of articles, and
 
 This is the ONLY valid way to terminate your task. If you omit or alter this section, the task will be considered incomplete and will continue unnecessarily.
 `;
+
+
+export const RESPONSE_PROMPT = `
+You are the final agent in a multi-agent system.
+Your job is to generate a short, user-friendly message explaining what was just built, based on the <task_summary> provided by the other agents.
+The application is a custom Next.js app tailored to the user's request.
+Reply in a casual tone, as if you're wrapping up the process for the user. No need to mention the <task_summary> tag.
+Your message should be 1 to 3 sentences, describing what the app does or what was changed, as if you're saying "Here's what I built for you."
+Do not add code, tags, or metadata. Only return the plain text response.
+`
+
+export const FRAGMENT_TITLE_PROMPT = `
+You are an assistant that generates a short, descriptive title for a code fragment based on its <task_summary>.
+The title should be:
+  - Relevant to what was built or changed
+  - Max 3 words
+  - Written in title case (e.g., "Landing Page", "Chat Widget")
+  - No punctuation, quotes, or prefixes
+
+Only return the raw title.
+`


### PR DESCRIPTION
This pull request enhances the `codeAgentFunction` in `src/inngest/functions.ts` by introducing state management, integrating new agents for generating responses and fragment titles, and improving database interactions. Additionally, it adds new prompt templates to support these features.

### Enhancements to the `codeAgentFunction`:

* **State Management**: Introduced `createState` to manage agent states, including a summary, files, and previous messages fetched from the database. This ensures a more structured and reusable state across agents (`[[1]](diffhunk://#diff-3e431ba483c49bf9dc6669ab5cd443a3d28fdc91e25480cf9a2c0030c88606b9L25-R58)`, `[[2]](diffhunk://#diff-3e431ba483c49bf9dc6669ab5cd443a3d28fdc91e25480cf9a2c0030c88606b9R173)`).

* **New Agents**: Added two agents:
  - `fragment-title-generator` for generating descriptive titles for code fragments using the `FRAGMENT_TITLE_PROMPT`.  
  - `response-generator` for creating user-friendly responses based on the task summary using the `RESPONSE_PROMPT` (`[src/inngest/functions.tsL151-R228](diffhunk://#diff-3e431ba483c49bf9dc6669ab5cd443a3d28fdc91e25480cf9a2c0030c88606b9L151-R228)`).

* **Dynamic Outputs**: Integrated methods to process outputs from the new agents (`generateFragmentTitle` and `generateResponse`) and use them dynamically when saving results to the database (`[src/inngest/functions.tsL178-R262](diffhunk://#diff-3e431ba483c49bf9dc6669ab5cd443a3d28fdc91e25480cf9a2c0030c88606b9L178-R262)`).

### Additions to `src/prompt.ts`:

* **New Prompt Templates**:
  - `RESPONSE_PROMPT`: Guides the `response-generator` agent to create concise, casual explanations of the task outcome.
  - [`FRAGMENT_TITLE_PROMPT`](diffhunk://#diff-d833a703f93cc16584da09140d24fdfe096e2322541e280054e192d1e6238edaR118-R138): Guides the `fragment-title-generator` agent to generate short, relevant titles for code fragments (`[src/prompt.tsR118-R138](diffhunk://#diff-d833a703f93cc16584da09140d24fdfe096e2322541e280054e192d1e6238edaR118-R138)`).